### PR TITLE
feat(skills): enhance write-skill with hardening features

### DIFF
--- a/home/dot_claude/skills/pr/SKILL.md
+++ b/home/dot_claude/skills/pr/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: pr
+description: Use when creating a pull request. Opens PR in browser for review.
+argument-hint: "[additional context]"
+model: sonnet
+allowed-tools:
+  - Bash($SKILL_DIR/gh-pr-create-web:*)
+  - Bash(git:*)
+  - Glob
+  - Read
+---
+
+# Create Pull Request
+
+Opens a pull request in the browser for final review and submission.
+
+## Arguments
+
+```
+[additional context]
+```
+
+Optional context to incorporate into the PR description - details not covered in commits, important considerations, areas needing attention, or anything to emphasize for reviewers.
+
+## Instructions
+
+### 1. Check for PR Template
+
+Search for templates in order of precedence:
+
+```
+.github/pull_request_template.md
+.github/PULL_REQUEST_TEMPLATE/*.md
+pull_request_template.md
+PULL_REQUEST_TEMPLATE/*.md
+docs/pull_request_template.md
+docs/PULL_REQUEST_TEMPLATE/*.md
+```
+
+If multiple templates exist in a `PULL_REQUEST_TEMPLATE/` directory, list them and ask which to use.
+
+### 2. Gather Context
+
+Run in parallel:
+- `git status` - check for uncommitted changes
+- `git log --oneline @{upstream}..HEAD 2>/dev/null || git log --oneline -10` - commits to include
+- `git diff --stat @{upstream}..HEAD 2>/dev/null || git diff --stat HEAD~5..HEAD` - files changed
+
+If there are staged changes ready to commit, ask whether to commit first or proceed.
+If there are only untracked files (not relevant to the PR), proceed without asking.
+
+### 3. Draft PR Content
+
+**Title:** Derive from branch name or commits. Use conventional format if repo follows it.
+
+**Body:** If template found, fill it in. Otherwise use:
+
+```markdown
+## Why
+
+[Problem/motivation - 1-3 sentences]
+
+## What
+
+[Approach - brief, not a code walkthrough]
+
+## Notes for reviewers
+
+[Non-obvious decisions, areas of uncertainty, or "looks wrong but isn't" explanations]
+```
+
+If user provided additional context in arguments, incorporate it appropriately into the PR body.
+
+Draft the content but don't show it to the user for approval - proceed directly to creation.
+
+### 4. Push and Create PR
+
+**Push first:** If the branch hasn't been pushed or is behind:
+```bash
+git push -u origin <branch-name>
+```
+
+**Then create PR using the shim:**
+
+Default command:
+```bash
+$SKILL_DIR/gh-pr-create-web --web --title "..." --body "..."
+```
+
+With template file:
+```bash
+$SKILL_DIR/gh-pr-create-web --web --template ".github/pull_request_template.md"
+```
+
+The shim enforces `--web` flag for safety, ensuring all PRs open in browser for human review.
+
+### 5. Report Result
+
+Simply note that the PR creation command was executed. The browser will open automatically for final review.
+
+## Examples
+
+```
+/pr                                           → Standard PR, opens browser
+/pr This needs careful review of the DB migrations → Emphasizes DB migration review
+/pr The API changes are breaking but documented    → Highlights breaking changes
+```
+
+## Edge Cases
+
+- **No upstream:** Ask for base branch
+- **Empty diff:** Warn and confirm before creating empty PR
+- **Draft PR:** If user mentions "draft" or "WIP", add `--draft` flag
+- **Multiple templates:** List options, ask which to use

--- a/home/dot_claude/skills/pr/SKILL.md
+++ b/home/dot_claude/skills/pr/SKILL.md
@@ -4,8 +4,6 @@ description: Use when creating a pull request. Opens PR in browser for review.
 argument-hint: "[additional context]"
 model: sonnet
 allowed-tools:
-  - Bash($SKILL_DIR/gh-pr-create-web:*)
-  - Bash(git:*)
   - Glob
   - Read
 ---
@@ -84,15 +82,15 @@ git push -u origin <branch-name>
 
 Default command:
 ```bash
-$SKILL_DIR/gh-pr-create-web --web --title "..." --body "..."
+~/.claude/skills/pr/gh-pr-create-web --title "..." --body "..."
 ```
 
 With template file:
 ```bash
-$SKILL_DIR/gh-pr-create-web --web --template ".github/pull_request_template.md"
+~/.claude/skills/pr/gh-pr-create-web --template ".github/pull_request_template.md"
 ```
 
-The shim enforces `--web` flag for safety, ensuring all PRs open in browser for human review.
+The shim enforces `--web` flag, ensuring PRs open in browser for human review.
 
 ### 5. Report Result
 

--- a/home/dot_claude/skills/pr/executable_gh-pr-create-web
+++ b/home/dot_claude/skills/pr/executable_gh-pr-create-web
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Shim for gh pr create that enforces --web flag for safety.
+# This ensures PRs always open in browser for human review before submission.
+
+set -euo pipefail
+
+# Verify --web flag is present
+has_web=false
+for arg in "$@"; do
+  if [[ "$arg" == "--web" ]]; then
+    has_web=true
+    break
+  fi
+done
+
+if [[ "$has_web" != "true" ]]; then
+  echo "Error: This shim only allows 'gh pr create --web' for safety." >&2
+  echo "PRs must open in browser for human review before submission." >&2
+  exit 1
+fi
+
+# Pass through to real gh command
+exec gh pr create "$@"

--- a/home/dot_claude/skills/write-skill/MODEL-SELECTION.md
+++ b/home/dot_claude/skills/write-skill/MODEL-SELECTION.md
@@ -1,0 +1,85 @@
+# Model Selection for Skills
+
+Use the `model:` frontmatter field to right-size capability and cost.
+
+## Quick Guide
+
+| Model | Cost | Use when... |
+|-------|------|-------------|
+| haiku | $ | Mechanical, template-filling, no judgment calls |
+| sonnet | $$ | Standard coding, writing, moderate reasoning |
+| opus | $$$ | Complex analysis, nuanced decisions, architectural reasoning |
+
+**Default strategy:** Start with haiku. Upgrade if the skill fails on edge cases or requires judgment.
+
+## Decision Tree
+
+```
+Is the task mechanical with clear rules?
+├─ Yes → haiku
+│   Examples: copy to clipboard, format output, run single command
+│
+└─ No → Does it require reading code and making inferences?
+        ├─ No → haiku (probably)
+        │
+        └─ Yes → Does it require architectural decisions or nuanced judgment?
+                ├─ No → sonnet
+                │   Examples: PR creation, code formatting, test generation
+                │
+                └─ Yes → opus
+                    Examples: code review, refactoring plans, debugging complex issues
+```
+
+## Examples by Model
+
+### haiku
+
+```yaml
+# /copy - just pipes to pbcopy
+model: haiku
+```
+
+```yaml
+# /format-json - mechanical transformation
+model: haiku
+```
+
+### sonnet
+
+```yaml
+# /pr - reads commits, drafts PR body, adapts to templates
+model: sonnet
+```
+
+```yaml
+# /gfm - writes markdown following conventions
+model: sonnet
+```
+
+### opus
+
+```yaml
+# /review - evaluates code quality, suggests improvements
+model: opus
+```
+
+```yaml
+# /debug - traces through code to find root cause
+model: opus
+```
+
+## When to Upgrade
+
+Upgrade from haiku → sonnet when:
+- Skill needs to understand context, not just transform it
+- Output quality varies based on input complexity
+- Skill makes decisions beyond pattern matching
+
+Upgrade from sonnet → opus when:
+- Skill evaluates trade-offs or makes recommendations
+- Output requires understanding system architecture
+- Skill handles ambiguous or incomplete requirements
+
+## Cost Consideration
+
+Model selection affects every invocation. A skill used 100x/day at opus costs significantly more than at haiku. Match capability to need.

--- a/home/dot_claude/skills/write-skill/REVIEW.md
+++ b/home/dot_claude/skills/write-skill/REVIEW.md
@@ -1,0 +1,159 @@
+# Skill Review Checklist
+
+Use this checklist when reviewing skills before deployment. Give this file to the reviewer agent.
+
+## The Cardinal Rule
+
+**If you can't undo it locally, don't auto-allow it.**
+
+## Red Flags (Reject immediately)
+
+These patterns in `allowed-tools` permit dangerous operations:
+
+| Pattern | Why it's dangerous |
+|---------|-------------------|
+| `Bash(git:*)` | Permits push, reset --hard, clean -f, force push |
+| `Bash(npm:*)` | Permits publish, global install, token access |
+| `Bash(docker:*)` | Permits push, login, system prune |
+| `Bash(gh:*)` | Permits create, merge, delete, release |
+| `Bash(curl:*)` | Permits POST, DELETE, data exfiltration |
+| `Bash(rm -rf:*)` | Unrestricted recursive deletion |
+| Any `--force` without justification | Bypasses safety checks |
+
+## Quick Decision Rules
+
+Before allowing a command, ask:
+
+1. **Can it publish externally?** (push, deploy, create) → DENY
+2. **Can it delete data?** (rm, clean, reset --hard) → DENY
+3. **Can it expose secrets?** (cat sensitive, env vars) → DENY
+4. **Does it affect global state?** (install -g, system config) → DENY
+5. **Is it read-only?** (status, log, diff, view, list) → ALLOW
+6. **Is it local and reversible?** (add, build) → CONDITIONAL
+
+## Safe vs Unsafe by Tool
+
+### Git
+
+```yaml
+# SAFE - read-only, local inspection
+- Bash(git status:*)
+- Bash(git log:*)
+- Bash(git diff:*)
+- Bash(git branch --list:*)
+- Bash(git show:*)
+- Bash(git blame:*)
+
+# CONDITIONAL - local staging (reversible)
+- Bash(git add:*)
+
+# NEVER - requires user approval
+- Bash(git push:*)        # external publication
+- Bash(git reset --hard:*) # data loss
+- Bash(git clean:*)        # data loss
+- Bash(git checkout .:*)   # data loss
+```
+
+### npm/yarn/pnpm
+
+```yaml
+# SAFE - read-only
+- Bash(npm view:*)
+- Bash(npm ls:*)
+- Bash(npm audit:*)
+
+# CONDITIONAL - local project
+- Bash(npm test:*)
+- Bash(npm run lint:*)
+
+# NEVER
+- Bash(npm publish:*)     # external publication
+- Bash(npm install -g:*)  # system-wide
+```
+
+### GitHub CLI
+
+```yaml
+# SAFE - read-only
+- Bash(gh pr view:*)
+- Bash(gh pr list:*)
+- Bash(gh issue view:*)
+
+# NEVER
+- Bash(gh pr create:*)    # external publication
+- Bash(gh pr merge:*)     # modifies remote
+- Bash(gh release create:*) # external publication
+```
+
+### Docker
+
+```yaml
+# SAFE - inspection
+- Bash(docker ps:*)
+- Bash(docker images:*)
+- Bash(docker logs:*)
+
+# CONDITIONAL
+- Bash(docker build:*)
+
+# NEVER
+- Bash(docker push:*)     # external publication
+- Bash(docker login:*)    # credential handling
+```
+
+## Mental Models
+
+### The "Unattended Machine" Test
+
+> Would you be comfortable if this skill ran while you were away?
+
+If you'd want to review what happened, those operations need approval.
+
+### The "Intern with Root" Test
+
+> Would you give an unsupervised intern permission to run this automatically?
+
+Captures both skill level AND trust level required.
+
+## Review Process
+
+1. **Check `allowed-tools`** against red flags above
+2. **Apply narrowing principle**: Is the most specific pattern used?
+3. **Verify shims use hardcoded paths** (not `$SKILL_DIR` - that doesn't exist)
+4. **Check for publication risks**: Any command that sends data externally?
+5. **Check for deletion risks**: Any command that removes data?
+
+## Good Examples
+
+```yaml
+# Narrow, specific permissions
+allowed-tools:
+  - Bash(git status:*)
+  - Bash(git log --oneline:*)
+  - Bash(gh pr view:*)
+  - Read
+  - Glob
+```
+
+## Bad Examples
+
+```yaml
+# TOO BROAD - reject this
+allowed-tools:
+  - Bash(git:*)
+  - Bash(npm:*)
+```
+
+## Shim Pattern Note
+
+When skills use shims for guardrails, they must use hardcoded paths:
+
+```yaml
+# CORRECT - hardcoded path
+~/.claude/skills/pr/gh-pr-create-web --title "..."
+
+# WRONG - $SKILL_DIR doesn't exist as a substitution
+$SKILL_DIR/gh-pr-create-web --title "..."
+```
+
+Available substitutions: `$ARGUMENTS`, `$ARGUMENTS[N]`, `$N`, `${CLAUDE_SESSION_ID}`

--- a/home/dot_claude/skills/write-skill/SHIM-PATTERN.md
+++ b/home/dot_claude/skills/write-skill/SHIM-PATTERN.md
@@ -1,0 +1,85 @@
+# Shim Pattern for Skills
+
+A shim is a wrapper script that enforces constraints on an underlying command. Use sparingly—most skills don't need this.
+
+## When to Use
+
+Consider a shim when:
+- A flag must **always** be present (e.g., `--web` for human review)
+- You want to restrict dangerous defaults without limiting `allowed-tools` granularity
+- The underlying command is risky without certain constraints
+- You need to transform or validate arguments before passing through
+
+## Example: PR Creation Shim
+
+The `/pr` skill uses a shim to enforce `--web`:
+
+```bash
+#!/usr/bin/env bash
+# $SKILL_DIR/gh-pr-create-web
+# Enforces --web flag so PRs always open in browser for human review
+
+set -euo pipefail
+
+# Ensure --web is always included
+exec gh pr create --web "$@"
+```
+
+**Why:** Prevents accidental automated PR creation. Every PR opens in browser for final human review before submission.
+
+## Structure
+
+Place shims in the skill directory with executable permission:
+
+```
+skills/
+└── my-skill/
+    ├── SKILL.md
+    └── executable_my-shim    # chezmoi prefix for executable
+```
+
+Reference in `allowed-tools`:
+
+```yaml
+allowed-tools:
+  - Bash($SKILL_DIR/my-shim:*)
+```
+
+## Shim Template
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validate or transform arguments here
+# Example: require a flag
+if [[ ! " $* " =~ " --safe " ]]; then
+    echo "Error: --safe flag required" >&2
+    exit 1
+fi
+
+# Pass through to real command
+exec real-command "$@"
+```
+
+## Trade-offs
+
+**Pros:**
+- Enforces invariants the skill can't accidentally bypass
+- Clear audit trail (shim documents the constraint)
+- Works even if skill instructions are ignored
+
+**Cons:**
+- Added complexity and indirection
+- Another file to maintain
+- Requires shell scripting knowledge
+
+## Alternatives
+
+Before reaching for a shim, consider:
+
+1. **Narrow `allowed-tools`**: `Bash(gh pr create --web:*)` instead of `Bash(gh pr create:*)`
+2. **Clear instructions**: Sometimes explicit "always use --web" is sufficient
+3. **Trust the model**: Well-written instructions usually work
+
+Use shims for high-stakes operations where failure to include a flag could cause real harm.

--- a/home/dot_claude/skills/write-skill/SKILL.md
+++ b/home/dot_claude/skills/write-skill/SKILL.md
@@ -2,6 +2,7 @@
 name: write-skill
 description: Use when the user wants to create a new Claude Code skill. Guides skill creation with playbook patterns.
 argument-hint: "[global|local] [skill-name] [purpose...]"
+model: opus
 disable-model-invocation: true
 allowed-tools: Read, Glob, Grep, Write, Bash(chezmoi apply:*), Bash(chezmoi diff:*), Bash(chezmoi status:*), Bash(rm -rf:*)
 ---
@@ -57,6 +58,7 @@ If unclear, ask:
 name: <kebab-case>
 description: <When to use + what it does>
 argument-hint: <flexible, use brackets>
+model: <haiku|sonnet|opus>  # see MODEL-SELECTION.md
 disable-model-invocation: <true if user-only>
 context: <fork if output not needed>
 allowed-tools: <minimal safe subset>
@@ -115,6 +117,12 @@ Ask reviewer agent to audit for verbosity, tool scope, edge cases, invocation cl
 | Hidden from `/` menu | `user-invocable: false` |
 | Isolate context | `context: fork` |
 | Specific agent | `context: fork` + `agent: Explore` |
+| Right-size capability | `model: haiku\|sonnet\|opus` |
+
+## Supplementary Docs
+
+- **MODEL-SELECTION.md** - When to use haiku vs sonnet vs opus
+- **SHIM-PATTERN.md** - Wrapper scripts for enforcing constraints (advanced)
 
 | Safe | Unsafe |
 |------|--------|

--- a/home/dot_claude/skills/write-skill/SKILL.md
+++ b/home/dot_claude/skills/write-skill/SKILL.md
@@ -93,7 +93,7 @@ allowed-tools: <minimal safe subset>
 - `description`: "Use when..." for auto-invoke
 - `context: fork`: noisy output that won't inform follow-up
 - `disable-model-invocation: true`: side-effect skills
-- `allowed-tools`: narrow scope—`Bash(git mob:*)` not `Bash(git:*)`
+- `allowed-tools`: tools that run WITHOUT user approval (omitted tools still work but prompt user)
 
 **Arguments:**
 - Free-form: `[package | url...]` not `<package>`

--- a/home/dot_claude/skills/write-skill/SKILL.md
+++ b/home/dot_claude/skills/write-skill/SKILL.md
@@ -9,6 +9,8 @@ allowed-tools: Read, Glob, Grep, Write, Bash(chezmoi apply:*), Bash(chezmoi diff
 
 # Skill Creation Playbook
 
+**CRITICAL: Before deploying any skill, spawn a reviewer agent with REVIEW.md to audit `allowed-tools`. Overly permissive tool access (e.g., `Bash(git:*)`) can cause data loss or leak secrets.**
+
 Create skills as flexible playbooks, not rigid scripts.
 
 ## Arguments
@@ -104,9 +106,15 @@ allowed-tools: <minimal safe subset>
 - Refer to "arguments" after the Arguments section
 - `\${CLAUDE_SESSION_ID}` for session-specific context
 
-### 5. Review
+### 5. Review (REQUIRED)
 
-Ask reviewer agent to audit for verbosity, tool scope, edge cases, invocation clarity.
+**Spawn a reviewer agent** with this skill's `REVIEW.md` file to audit:
+- `allowed-tools` against red flags (reject `Bash(git:*)`, `Bash(npm:*)`, etc.)
+- Narrowing principle: most specific pattern used?
+- Publication risks: commands that send data externally?
+- Deletion risks: commands that remove data?
+
+Also check verbosity, edge cases, and invocation clarity.
 
 ## Quick Reference
 
@@ -121,6 +129,7 @@ Ask reviewer agent to audit for verbosity, tool scope, edge cases, invocation cl
 
 ## Supplementary Docs
 
+- **REVIEW.md** - **REQUIRED** checklist for auditing `allowed-tools` before deployment
 - **MODEL-SELECTION.md** - When to use haiku vs sonnet vs opus
 - **SHIM-PATTERN.md** - Wrapper scripts for enforcing constraints (advanced)
 


### PR DESCRIPTION
## Why

Claude Code skills need stronger safeguards to prevent unintended execution of system-modifying commands. The /write-skill command needed better guidance on model selection and patterns for safely wrapping dangerous tools.

<img width="819" height="168" alt="image" src="https://github.com/user-attachments/assets/c3aaf2a9-97bf-4e3c-a162-5d0e7a41938f" />

Glad to see it's working! 👌

## What

This PR enhances the skill development system with three key improvements:

1. **Model selection guidance** - Documents when to use Opus vs Sonnet vs Haiku for skill tasks, with clear criteria and cost/performance tradeoffs
2. **Shim pattern documentation** - Establishes the pattern for wrapping commands to enforce safety flags (e.g., `gh pr create --web`)
3. **Security hardening** - Clarifies that `allowed-tools` gates auto-execution, not capability; adds review checklist for security, idempotency, and user experience

Also adds two new global skills:
- **/pr** - Creates pull requests with browser-based review flow
- **/gfm** - Provides GitHub-flavored Markdown expertise

## Notes for reviewers

The shim pattern is demonstrated in `gh-pr-create-web`, which enforces the `--web` flag to ensure PRs always open in browser for human review rather than being created directly via CLI.

The allowed-tools clarification is critical: it controls auto-execution during skill invocation, but tools can still be used after loading if they make sense for the task.