### PR TITLE
Add /agents-local-md skill for machine-specific context :sparkles:

### DIFF
--- a/.claude/skills/agents-local-md/SKILL.md
+++ b/.claude/skills/agents-local-md/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: agents-local-md
+description: "Generate machine-specific AGENTS.local.md with host facts, tool provenance, and platform quirks"
+argument-hint: "[--force]"
+model: sonnet
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash(uname:*)
+  - Bash(hostname:*)
+  - Bash(command -v:*)
+  - Bash(which:*)
+  - Bash(zsh --version:*)
+  - Bash(tmux -V:*)
+  - Bash(nvim --version:*)
+  - Bash(git --version:*)
+  - Bash(mise ls:*)
+  - Bash(mise where:*)
+  - Bash(mise doctor:*)
+  - Bash(chezmoi data:*)
+  - Bash(chezmoi ignored:*)
+  - Bash(chezmoi managed:*)
+  - Bash(chezmoi doctor:*)
+  - Bash(readlink:*)
+  - Bash(test -f:*)
+  - Bash(test -L:*)
+  - Bash(ls:*)
+  - Bash(cat /etc/os-release:*)
+  - Bash(delta --version:*)
+  - Bash(starship --version:*)
+  - Bash(gh --version:*)
+  - Bash(stat:*)
+  - Bash(date:*)
+  # NOTE: Write and ln require user approval (intentional)
+---
+
+# Generate AGENTS.local.md
+
+Probe this machine's environment and write `AGENTS.local.md` — a machine-specific context file that Claude Code auto-loads via `CLAUDE.local.md` symlink. Facts only, no duplication with `AGENTS.md`.
+
+## Arguments
+
+```
+$ARGUMENTS
+```
+
+Options:
+- `--force` — regenerate even if the file is fresh
+
+## Instructions
+
+### 1. Freshness Check
+
+If `AGENTS.local.md` exists in the repo root:
+
+```bash
+stat -c %Y AGENTS.local.md 2>/dev/null || stat -f %m AGENTS.local.md 2>/dev/null
+```
+
+Read the file and extract the `Generated:` line. If ALL of these are true, report "AGENTS.local.md is current (generated DATE on HOSTNAME)" and **stop**:
+- File is less than 7 days old
+- Hostname in file matches current hostname
+- OS in file matches current OS
+- `--force` was NOT passed in arguments
+
+Otherwise, continue to regenerate.
+
+### 2. Probe System Identity
+
+Gather:
+```bash
+uname -s        # OS kernel (Darwin/Linux)
+uname -m        # Architecture (x86_64/arm64)
+hostname -s     # Short hostname
+cat /etc/os-release  # Linux distro details (skip on macOS)
+```
+
+### 3. Probe Package Manager
+
+Determine which system package manager is available:
+- macOS: `command -v brew`
+- Linux: `command -v dnf` or `command -v apt`
+
+Note how chezmoi uses it (check `home/.chezmoidata/packages.yaml`).
+
+### 4. Probe Tool Versions & Provenance
+
+For each tool: **zsh, tmux, nvim, git, mise, delta, starship, gh**
+
+Collect:
+- Version: run `<tool> --version` (or equivalent)
+- Path: `command -v <tool>`
+- Source: determine provenance:
+  - If path contains `/mise/` → "mise"
+  - If path contains `/brew/` or `/Homebrew/` → "brew"
+  - If path is `/usr/bin/` or `/usr/sbin/` → "system"
+  - If path contains `/nix/` → "nix"
+  - Otherwise → note the actual path
+
+Use `mise ls` to cross-reference which tools mise manages.
+
+### 5. Probe Platform Quirks
+
+Check for known issues and platform-specific facts:
+
+**Fedora Linux:**
+- Is eza available via system package? (`command -v eza`)
+- Is dust available via system package? (`command -v dust`)
+- How was mise installed? (COPR, curl, or mise shims path)
+- Mise shims path: `ls ~/.local/share/mise/shims/` exists?
+
+**macOS:**
+- Homebrew prefix: `command -v brew && brew --prefix`
+- GNU coreutils installed? (`command -v gdircolors`)
+
+**Both platforms:**
+- 1Password SSH agent socket: check if socket exists at platform-appropriate path
+- Docker/Podman: `command -v docker` and `command -v podman`
+
+### 6. Analyze Chezmoi Platform View
+
+```bash
+chezmoi data --format json | grep -E '"os"|"arch"|"hostname"'
+chezmoi ignored
+```
+
+Read `.chezmoiignore` to summarize what's excluded on this platform.
+
+### 7. Write AGENTS.local.md
+
+Write the file to the **repo root** (`AGENTS.local.md`). Target <80 lines. Use this structure:
+
+```markdown
+# AGENTS.local.md
+
+> Machine-specific context for coding agents. Auto-generated — do not edit.
+> Regenerate with `/agents-local-md --force`.
+
+Generated: YYYY-MM-DD on HOSTNAME (OS ARCH)
+
+## System
+
+- **OS:** e.g., Fedora 42 (Linux 6.x) / macOS 15.x (Darwin)
+- **Arch:** x86_64 / arm64
+- **Package manager:** dnf / brew
+
+## Tool Provenance
+
+| Tool | Version | Source | Path |
+|------|---------|--------|------|
+| zsh | 5.9 | system | /usr/bin/zsh |
+| tmux | 3.5a | system | /usr/bin/tmux |
+| nvim | 0.10.x | mise | ~/.local/share/mise/installs/... |
+| ... | ... | ... | ... |
+
+## Platform Quirks
+
+- List of notable platform-specific facts
+- e.g., "eza not in Fedora repos — installed via mise"
+- e.g., "1Password SSH agent at ~/.1password/agent.sock"
+- e.g., "Podman available, Docker is not"
+
+## Chezmoi View
+
+- **Excluded on this platform:** list from .chezmoiignore
+- **Active templates:** count of .tmpl files with platform guards
+```
+
+**Rules for content:**
+- Facts only — no opinions, no recommendations
+- No duplication with `AGENTS.md` (which covers repo structure and workflow)
+- No upstream documentation content
+- No session-ephemeral data (PID, uptime, load)
+- Truncate long paths with `~` for home directory
+
+### 8. Create Symlink
+
+```bash
+ln -sf AGENTS.local.md CLAUDE.local.md
+```
+
+This makes Claude Code auto-load the file as `CLAUDE.local.md`.
+
+### 9. Verify
+
+```bash
+test -f AGENTS.local.md && echo "AGENTS.local.md exists"
+test -L CLAUDE.local.md && readlink CLAUDE.local.md
+git status AGENTS.local.md CLAUDE.local.md
+```
+
+Confirm:
+- `AGENTS.local.md` exists and has content
+- `CLAUDE.local.md` is a symlink pointing to `AGENTS.local.md`
+- Both are gitignored (should not appear in `git status`)
+
+Report: "Generated AGENTS.local.md (N lines) — CLAUDE.local.md symlinked. Both gitignored."

--- a/.claude/skills/agents-local-md/SKILL.md
+++ b/.claude/skills/agents-local-md/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agents-local-md
-description: "Generate machine-specific AGENTS.local.md with host facts, tool provenance, and platform quirks"
+description: "Generate machine-specific AGENTS.local.md with host facts and system tool details"
 argument-hint: "[--force]"
 model: sonnet
 disable-model-invocation: true
@@ -15,22 +15,11 @@ allowed-tools:
   - Bash(zsh --version:*)
   - Bash(tmux -V:*)
   - Bash(nvim --version:*)
-  - Bash(git --version:*)
-  - Bash(mise ls:*)
-  - Bash(mise where:*)
-  - Bash(mise doctor:*)
   - Bash(chezmoi data:*)
-  - Bash(chezmoi ignored:*)
-  - Bash(chezmoi managed:*)
-  - Bash(chezmoi doctor:*)
   - Bash(readlink:*)
   - Bash(test -f:*)
   - Bash(test -L:*)
-  - Bash(ls:*)
   - Bash(cat /etc/os-release:*)
-  - Bash(delta --version:*)
-  - Bash(starship --version:*)
-  - Bash(gh --version:*)
   - Bash(stat:*)
   - Bash(date:*)
   # NOTE: Write and ln require user approval (intentional)
@@ -38,7 +27,7 @@ allowed-tools:
 
 # Generate AGENTS.local.md
 
-Probe this machine's environment and write `AGENTS.local.md` — a machine-specific context file that Claude Code auto-loads via `CLAUDE.local.md` symlink. Facts only, no duplication with `AGENTS.md`.
+Probe this machine's environment and write `AGENTS.local.md` — a machine-specific context file that Claude Code auto-loads via `CLAUDE.local.md` symlink.
 
 ## Arguments
 
@@ -77,60 +66,31 @@ hostname -s     # Short hostname
 cat /etc/os-release  # Linux distro details (skip on macOS)
 ```
 
-### 3. Probe Package Manager
-
 Determine which system package manager is available:
 - macOS: `command -v brew`
 - Linux: `command -v dnf` or `command -v apt`
 
-Note how chezmoi uses it (check `home/.chezmoidata/packages.yaml`).
+### 3. Probe Core System Tools
 
-### 4. Probe Tool Versions & Provenance
+Only probe tools that **vary across systems and affect agent behavior**: **zsh, tmux, nvim**.
 
-For each tool: **zsh, tmux, nvim, git, mise, delta, starship, gh**
+These are system-installed, version-significant tools where the difference between (say) zsh 5.8 vs 5.9, tmux 3.3 vs 3.5, or nvim 0.9 vs 0.11 changes what features/APIs are available. Mise-pinned tools are the same everywhere — don't list them.
 
-Collect:
-- Version: run `<tool> --version` (or equivalent)
+For each tool, collect:
+- Version: `zsh --version`, `tmux -V`, `nvim --version`
 - Path: `command -v <tool>`
-- Source: determine provenance:
-  - If path contains `/mise/` → "mise"
-  - If path contains `/brew/` or `/Homebrew/` → "brew"
-  - If path is `/usr/bin/` or `/usr/sbin/` → "system"
-  - If path contains `/nix/` → "nix"
-  - Otherwise → note the actual path
 
-Use `mise ls` to cross-reference which tools mise manages.
-
-### 5. Probe Platform Quirks
-
-Check for known issues and platform-specific facts:
-
-**Fedora Linux:**
-- Is eza available via system package? (`command -v eza`)
-- Is dust available via system package? (`command -v dust`)
-- How was mise installed? (COPR, curl, or mise shims path)
-- Mise shims path: `ls ~/.local/share/mise/shims/` exists?
-
-**macOS:**
-- Homebrew prefix: `command -v brew && brew --prefix`
-- GNU coreutils installed? (`command -v gdircolors`)
-
-**Both platforms:**
-- 1Password SSH agent socket: check if socket exists at platform-appropriate path
-- Docker/Podman: `command -v docker` and `command -v podman`
-
-### 6. Analyze Chezmoi Platform View
+### 4. Chezmoi Platform Detection
 
 ```bash
 chezmoi data --format json | grep -E '"os"|"arch"|"hostname"'
-chezmoi ignored
 ```
 
-Read `.chezmoiignore` to summarize what's excluded on this platform.
+Record what chezmoi sees — this is what drives template conditionals.
 
-### 7. Write AGENTS.local.md
+### 5. Write AGENTS.local.md
 
-Write the file to the **repo root** (`AGENTS.local.md`). Target <80 lines. Use this structure:
+Write the file to the **repo root** (`AGENTS.local.md`). Target **<30 lines**. Use this structure:
 
 ```markdown
 # AGENTS.local.md
@@ -142,48 +102,40 @@ Generated: YYYY-MM-DD on HOSTNAME (OS ARCH)
 
 ## System
 
-- **OS:** e.g., Fedora 42 (Linux 6.x) / macOS 15.x (Darwin)
-- **Arch:** x86_64 / arm64
-- **Package manager:** dnf / brew
+- **OS:** Fedora 42 (Linux 6.x) / macOS 15.x (Darwin)
+- **Arch:** x86_64 (amd64) / arm64
+- **Hostname:** name
+- **Package manager:** dnf (`/usr/bin/dnf`) / brew (`/opt/homebrew/bin/brew`)
 
-## Tool Provenance
+## Core Tools
 
-| Tool | Version | Source | Path |
-|------|---------|--------|------|
-| zsh | 5.9 | system | /usr/bin/zsh |
-| tmux | 3.5a | system | /usr/bin/tmux |
-| nvim | 0.10.x | mise | ~/.local/share/mise/installs/... |
-| ... | ... | ... | ... |
+| Tool | Version | Path |
+|------|---------|------|
+| zsh | 5.9 | `/usr/bin/zsh` |
+| tmux | 3.5a | `/usr/bin/tmux` |
+| nvim | 0.11.5 | `/usr/bin/nvim` |
 
-## Platform Quirks
+## Chezmoi Platform
 
-- List of notable platform-specific facts
-- e.g., "eza not in Fedora repos — installed via mise"
-- e.g., "1Password SSH agent at ~/.1password/agent.sock"
-- e.g., "Podman available, Docker is not"
-
-## Chezmoi View
-
-- **Excluded on this platform:** list from .chezmoiignore
-- **Active templates:** count of .tmpl files with platform guards
+chezmoi sees: os=`linux`, arch=`amd64`, hostname=`core`
 ```
 
-**Rules for content:**
-- Facts only — no opinions, no recommendations
-- No duplication with `AGENTS.md` (which covers repo structure and workflow)
-- No upstream documentation content
-- No session-ephemeral data (PID, uptime, load)
-- Truncate long paths with `~` for home directory
+**What belongs here:** facts that vary across machines and change agent behavior.
 
-### 8. Create Symlink
+**What does NOT belong:**
+- Mise-pinned tools (same everywhere)
+- Third-party tools available in homebrew (latest everywhere)
+- Facts already documented in the codebase (eza/dust Fedora gaps, mise wrapper alias)
+- Session-ephemeral data (PID, uptime, load)
+- Tool counts, shim counts, template counts
+
+### 6. Create Symlink
 
 ```bash
 ln -sf AGENTS.local.md CLAUDE.local.md
 ```
 
-This makes Claude Code auto-load the file as `CLAUDE.local.md`.
-
-### 9. Verify
+### 7. Verify
 
 ```bash
 test -f AGENTS.local.md && echo "AGENTS.local.md exists"
@@ -192,8 +144,8 @@ git status AGENTS.local.md CLAUDE.local.md
 ```
 
 Confirm:
-- `AGENTS.local.md` exists and has content
-- `CLAUDE.local.md` is a symlink pointing to `AGENTS.local.md`
+- `AGENTS.local.md` exists with content
+- `CLAUDE.local.md` symlink points to `AGENTS.local.md`
 - Both are gitignored (should not appear in `git status`)
 
 Report: "Generated AGENTS.local.md (N lines) — CLAUDE.local.md symlinked. Both gitignored."

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -13,6 +13,7 @@ allowed-tools:
   - Bash(git stash:*)
   - Bash(git add:*)
   - Bash(chezmoi diff:*)
+  - Bash(test -f:*)
   - Read
   # NOTE: These require user approval for safety:
   # - gh pr merge (modifies remote state)
@@ -37,6 +38,20 @@ Options:
 - `--dry-run` - Show what would be done without making changes
 
 ## Instructions
+
+### 0. Check AGENTS.local.md Freshness
+
+```bash
+test -f AGENTS.local.md && echo "exists" || echo "missing"
+```
+
+If the file exists, read it and check the `Generated:` date line.
+
+- **Missing:** suggest "Run `/agents-local-md` to generate machine-specific context"
+- **Older than 7 days:** suggest "Run `/agents-local-md --force` to refresh machine context"
+- **Fresh:** no action needed
+
+This is **advisory only** — continue the update regardless.
 
 ### 1. Check for Uncommitted Work
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /docs/gitingest
+AGENTS.local.md
+CLAUDE.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # AGENTS.md
 
+@AGENTS.local.md
+
 Personal dotfiles managed by coding agents via [Chezmoi](https://www.chezmoi.io/). Targets macOS (darwin) and Fedora Linux. See [docs/vision.md](docs/vision.md) and [docs/core-principles.md](docs/core-principles.md) for the philosophy behind this setup.
 
 ## The Stack

--- a/home/dot_claude/skills/agents-md/SKILL.md
+++ b/home/dot_claude/skills/agents-md/SKILL.md
@@ -36,6 +36,7 @@ The following checks ran before this skill was invoked:
 **CLAUDE.md exists:** !`test -e CLAUDE.md && echo "yes" || echo "no"`
 **CLAUDE.md is symlink:** !`test -L CLAUDE.md && echo "yes" || echo "no"`
 **CLAUDE.md symlink target:** !`readlink CLAUDE.md 2>/dev/null || echo "(not a symlink or does not exist)"`
+**AGENTS.local.md exists:** !`test -f AGENTS.local.md && echo "yes" || echo "no"`
 
 Use this context to skip redundant checks. If CLAUDE.md is already a symlink pointing to AGENTS.md, don't recreate it.
 
@@ -134,6 +135,7 @@ Follow THIS structure (keep each section short and skimmable):
 ### 3. Implementation Details (files + symlink)
 
 - Write `AGENTS.md` where specified.
+- If `AGENTS.local.md` exists, include `@AGENTS.local.md` near the top of the file (e.g. right after the title or introduction). Agents read `@`-references intuitively — no markdown link or explanation needed. Some projects provide a local `/agents-local-md` skill to generate this file — if the project has one, suggest running it.
 - Create/update the symlink so `CLAUDE.md` -> `AGENTS.md` (relative symlink).
 - If `CLAUDE.md` exists as a real file, replace it with a symlink.
 


### PR DESCRIPTION
## Why

Every agent session starts with zero knowledge of the host. Agents independently probe the same system facts — identical work, every time. This PR introduces `/agents-local-md`, a skill that probes once and writes `AGENTS.local.md` (symlinked as `CLAUDE.local.md`), which Claude Code auto-loads. Machine-specific context, gitignored, amortized across all sessions.

Closes #127

## What

- **New skill:** `.claude/skills/agents-local-md/SKILL.md` — probes system identity (OS, arch, hostname, package manager), core system tools (zsh, tmux, nvim versions), and chezmoi platform detection. Generates `AGENTS.local.md` (<30 lines) with facts that vary across machines and affect agent behavior.
- **Gitignore:** Excludes `AGENTS.local.md` and `CLAUDE.local.md` from version control.
- **AGENTS.md integration:** Added `@AGENTS.local.md` reference at the top — agents follow `@`-references intuitively.
- **Global `/agents-md` skill update:** When generating/updating `AGENTS.md`, automatically includes `@AGENTS.local.md` if the file exists.
- **`/update` skill enhancement:** Step 0 checks freshness of `AGENTS.local.md` and suggests regeneration if >7 days old or missing (advisory only, doesn't block update).

## Notes for reviewers

The skill was initially over-engineered (probed mise-pinned tools, platform quirks already in the codebase, counted templates/shims). Revised to focus on **only** what varies across machines: system identity, core tool versions (zsh/tmux/nvim), and chezmoi platform detection. Target output is <30 lines.

The skill intentionally excludes `Write` and `ln` from `allowed-tools` — both require user approval as a safety feature.

---

🤖 [Conversation log](https://gist.github.com/ivy/445233bc689d8556b2539f25f1dd2f9b)