### PR TITLE
chore(mise): use catppuccin color theme

### DIFF
--- a/home/dot_config/mise/config.toml
+++ b/home/dot_config/mise/config.toml
@@ -9,6 +9,7 @@
 #   5. npm: - Node CLI tools (requires node)
 
 [settings]
+color_theme = "catppuccin"
 lockfile = true
 
 [tools]


### PR DESCRIPTION
Set color_theme = "catppuccin" in mise settings for consistent
theming with the rest of the environment.

Closes #194

https://claude.ai/code/session_01A6YupKZxt1MP2wDszXJ65n