### PR TITLE
git: prune stale remote-tracking branches on fetch

### DIFF
--- a/home/dot_config/git/config.tmpl
+++ b/home/dot_config/git/config.tmpl
@@ -28,6 +28,9 @@
 [pull]
 	rebase = true
 
+[fetch]
+	prune = true
+
 [push]
 	default = simple
 	autoSetupRemote = true


### PR DESCRIPTION
Add fetch.prune = true to git config so that stale remote-tracking
branches are automatically removed during fetch/pull operations.

Closes #136

https://claude.ai/code/session_01JRXit87gapfgk4JEBBi8E2