### PR TITLE
feat: add zoxide for fast directory jumping (#241)

### DIFF
--- a/home/dot_config/mise/config.toml
+++ b/home/dot_config/mise/config.toml
@@ -45,6 +45,7 @@ eza = "0.23.4"
 "github:BurntSushi/ripgrep" = "15.1.0"
 "github:starship/starship" = "1.24.2"
 "github:mikefarah/yq" = "4.52.4"
+"github:ajeetdsouza/zoxide" = "0.9.9"
 
 # pipx itself (must be installed before any pipx: packages below)
 pipx = "1.8.0"

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -36,6 +36,11 @@ source "$ZSH"/oh-my-zsh.sh
 eval "$(atuin init zsh)"
 {{- end }}
 
+# Initialize zoxide for fast directory jumping
+{{- if lookPath "zoxide" }}
+eval "$(zoxide init zsh)"
+{{- end }}
+
 {{- $zshAutoSuggestPath := joinPath .chezmoi.homeDir ".config/zsh/plugins/zsh-autosuggestions/zsh-autosuggestions.zsh" }}
 {{- if stat $zshAutoSuggestPath }}
 


### PR DESCRIPTION
Install zoxide v0.9.9 via mise github: backend and initialize it in the
interactive zsh section (gated by envsense, same as atuin).

https://claude.ai/code/session_012i5fzAMM9VoYq2CefPLsNT