### PR TITLE
Remove fork context requirement from commit skill

### DIFF
--- a/home/dot_claude/skills/commit/SKILL.md.tmpl
+++ b/home/dot_claude/skills/commit/SKILL.md.tmpl
@@ -3,7 +3,6 @@ name: commit
 description: Use when committing code changes. Enforces intentional file selection, conventional commits, and why-focused messages.
 argument-hint: "[message | --amend | files...]"
 {{- template "bedrock-model" (dict "tier" "sonnet" "root" .) }}
-context: fork
 allowed-tools:
   - Bash(git status:*)
   - Bash(git diff:*)


### PR DESCRIPTION
## Summary
Removed the `context: fork` configuration line from the commit skill definition, allowing the skill to operate outside of fork-only contexts.

## Changes
- Removed `context: fork` constraint from `SKILL.md.tmpl`

## Details
This change makes the commit skill more broadly applicable by removing the fork context restriction. The skill will now be available for use in additional contexts beyond just fork operations, while maintaining all other constraints including conventional commit enforcement and intentional file selection.

https://claude.ai/code/session_01JPNargVEkGuJ1MV36UQnwW