### PR TITLE
Add [1m] suffix to Opus and Sonnet model configurations

### DIFF
--- a/bin/sync-claude-settings
+++ b/bin/sync-claude-settings
@@ -100,6 +100,11 @@ merge_model_env_vars() {
         return 1
     fi
 
+    # Append [1m] suffix to Opus and Sonnet for 1M token context window
+    # (Haiku does not support extended context)
+    opus="${opus}[1m]"
+    sonnet="${sonnet}[1m]"
+
     printf 'haiku  = %s\n' "${haiku}"
     printf 'sonnet = %s\n' "${sonnet}"
     printf 'opus   = %s\n' "${opus}"


### PR DESCRIPTION
## Summary
Updated the `merge_model_env_vars()` function to append the `[1m]` suffix to Claude Opus and Sonnet model identifiers, enabling the 1 million token context window variant for these models.

## Changes
- Appended `[1m]` suffix to `opus` and `sonnet` variables in the model configuration merge function
- Added explanatory comments noting that Haiku does not support extended context and therefore does not receive the suffix
- This change allows users to leverage the extended context capabilities of Opus and Sonnet models when syncing Claude settings

## Implementation Details
The suffix is applied after environment variable merging but before the final output, ensuring that both explicitly set and default model configurations receive the extended context window designation.

https://claude.ai/code/session_01M5JxmXPfnx3Rf6SQQwcxZq