### PR TITLE
fix(skills): /plan — append tasks instead of clobbering existing list :bug:

### DIFF
--- a/home/dot_claude/skills/plan/SKILL.md.tmpl
+++ b/home/dot_claude/skills/plan/SKILL.md.tmpl
@@ -16,6 +16,9 @@ allowed-tools:
   - Glob
   - Grep
   - Read
+  - TaskCreate
+  - TaskList
+  - TaskUpdate
 ---
 
 # Plan: Parallelized Implementation Design
@@ -133,4 +136,12 @@ Write the plan file with:
 
 ### 8. Exit Plan Mode
 
-Call `ExitPlanMode` and await approval. After approval, the executing agent (or `/work-on` orchestrator) will use `TaskCreate` to instantiate the task graph with proper `addBlockedBy`/`addBlocks` relationships.
+Call `ExitPlanMode`. The user will approve or request changes before you proceed.
+
+### 9. Create Tasks (append, never replace)
+
+Once the plan is approved, instantiate the task graph as tasks. **If tasks already exist** (e.g., workflow tasks from `/work-on`), append implementation tasks — never clear or replace the existing list.
+
+1. Call `TaskList` to discover existing tasks
+2. Create each implementation task via `TaskCreate` with proper `addBlockedBy`/`addBlocks` relationships
+3. If an existing task is a placeholder for plan work (e.g., "Implement per plan"), call `TaskUpdate` to mark it `completed` and wire your first implementation task with `addBlockedBy` pointing to that placeholder's upstream dependencies


### PR DESCRIPTION
## Why

When `/plan` creates implementation tasks after plan approval, it replaces the existing task list instead of appending. This wipes out workflow tasks created by `/work-on` (e.g., `/share-plan`, `/simplify`, `/reflect`), causing skipped steps and lost sequencing.

## What

- Splits old Step 8 into two steps: exit plan mode (Step 8), then create tasks (Step 9)
- Step 9 explicitly requires calling `TaskList` first and appending — never clearing or replacing the existing list
- Placeholder tasks (e.g., "Implement per plan") get marked `completed` via `TaskUpdate` so implementation tasks slot in cleanly
- Adds `TaskCreate`, `TaskList`, and `TaskUpdate` to `allowed-tools` — without these the agent would be blocked from executing Step 9 entirely

## Notes for reviewers

The `allowed-tools` gap was caught in a prompt-engineer review of the new step: the original fix had the right logic but referenced tools the skill wasn't permitted to call. Both issues are addressed in the single commit.

The #324 fix added a recovery rule in `/work-on` Step 3 (re-create removed tasks after each skill invocation). This PR fixes the source in `/plan` so the recovery rule is a backstop rather than load-bearing.

Closes #320
