### PR TITLE
feat(skills): /plan — parallelization mandate, bias toward action :sparkles:

### DIFF
--- a/home/dot_claude/skills/plan/README.md
+++ b/home/dot_claude/skills/plan/README.md
@@ -31,7 +31,7 @@ The agent reads the context from the conversation and builds the task graph.
 ## What a plan contains
 
 - **Task graph** — discrete tasks with explicit `blockedBy` / `blocks` relationships
-- **Parallelization strategy** — which tasks run concurrently and why
+- **Parallelization summary** — table of parallel groups with justification for why they are independent
 - **Agent assignments** — which agent type handles each task (`Explore`, `general-purpose`, `reviewer`, or project-specific agents)
 - **Isolation decisions** — which tasks need worktree isolation (two agents touching the same file)
 - **Checkpoints** — where human review is needed before downstream tasks can proceed
@@ -41,7 +41,7 @@ The plan requires your approval before execution begins. This is the last checkp
 
 ## The EnterPlanMode contract
 
-[`/plan`](../plan/README.md) uses `EnterPlanMode`, which means it presents the plan and waits for explicit sign-off. The approved plan then drives `TaskCreate` calls with proper `addBlockedBy` relationships — the task list becomes the execution contract.
+[`/plan`](../plan/README.md) uses `EnterPlanMode`, which means it presents the plan and waits for explicit sign-off. Approval is the execution signal — the agent proceeds immediately to `TaskCreate` calls with proper `addBlockedBy` relationships. No pause, no "shall I proceed?".
 
 Changing your mind after approval is fine: the task list is a living document. Tasks can be updated, deleted, or added as the implementation reveals new information.
 

--- a/home/dot_claude/skills/plan/SKILL.md.tmpl
+++ b/home/dot_claude/skills/plan/SKILL.md.tmpl
@@ -44,6 +44,19 @@ CLAUDE.md exists: !`test -f CLAUDE.md && echo "yes" || echo "no"`
 - Never use `git -C <path>` — it rewrites the command prefix, breaking `allowed-tools` pattern matching.
 - Focus on **parallelization and dependencies** — this is the skill's core value. Claude Code doesn't naturally optimize for these.
 
+## Parallelization Mandate
+
+**Linear plans are a failure mode.** This skill exists because sequential A → B → C wastes time when B and C are independent.
+
+Before presenting any plan, verify each of these holds:
+
+1. Does every independent task have **no** `blockedBy`? It should be ready to run immediately.
+2. Does every `blockedBy` reflect a **real data dependency** — task B genuinely needs task A's output, not just ordering preference?
+3. Does at least one phase contain **multiple parallel tasks**? If not, state the specific reason all work is serialized — do not silently omit this.
+4. Are parallel phases **explicitly labeled** as `(parallel)` in the plan output?
+
+A plan where every task blocks the next is wrong. Find the parallelism before presenting.
+
 ## Instructions
 
 ### 1. Enter Plan Mode
@@ -68,6 +81,12 @@ Break the work into discrete, well-defined tasks. For each task, determine:
 | **Agent type** | What kind of agent is best suited? (Explore, general-purpose, reviewer, project-specific) |
 | **Isolation** | Does this task benefit from worktree isolation? (yes if it touches files another task also touches) |
 | **Checkpoint** | Should human review the output before downstream tasks proceed? |
+
+After listing all tasks, do an explicit **parallelization pass**. Start from the assumption that all tasks are independent — add `blockedBy` only when the test below fails:
+
+1. Group tasks by the files they touch. Tasks in different file groups are candidates for parallel execution.
+2. For each pair, ask: does task B need task A's *output* to start, or just task A to *exist*? Only the former is a real dependency.
+3. Tasks that survive this test keep no `blockedBy`. Tasks that fail get `blockedBy` with a one-line reason why.
 
 ### 4. Design the Task Graph
 
@@ -124,21 +143,36 @@ Plan the commit sequence:
 
 ### 7. Present the Plan
 
-Write the plan file with:
+Write the plan with:
 
 1. **Overview** — one paragraph summary of what the plan achieves
 2. **Task graph** — tasks with dependencies, agents, and phases (as in step 4)
-3. **Parallelization strategy** — what runs concurrently, why, and expected speedup
+3. **Parallelization summary** — a concise table listing each parallel group, the tasks in it, and why they are independent:
+   ```
+   | Phase | Tasks | Why parallel |
+   |-------|-------|-------------|
+   | 1     | A, B  | Touch different files (src/foo.ts, src/bar.ts) |
+   | 3     | D, E  | Review and test are independent of each other |
+   ```
 4. **Team topology** — agents, roles, isolation (if applicable)
 5. **Checkpoints** — where human review is needed before proceeding
 6. **Commit strategy** — what gets committed when
 7. **Risk flags** — assumptions that might be wrong, areas that might need adjustment
 
-### 8. Exit Plan Mode
+### 8. Verify Before Presenting
 
-Call `ExitPlanMode`. The user will approve or request changes before you proceed.
+Before calling `ExitPlanMode`, run through the [Parallelization Mandate](#parallelization-mandate) checklist. If any item fails:
+- Find the independent work and move it out of the serial chain
+- Remove `blockedBy` from tasks that don't have real data dependencies
+- Re-label phases to reflect the corrected structure
 
-### 9. Create Tasks (append, never replace)
+A plan that fails the mandate should not be presented.
+
+### 9. Exit Plan Mode
+
+Call `ExitPlanMode` and await approval. The user's approval of the plan is the execution signal. Your next action after approval is Step 10 — not a summary, not "shall I proceed?", not a pause.
+
+### 10. Create Tasks (append, never replace)
 
 Once the plan is approved, instantiate the task graph as tasks. **If tasks already exist** (e.g., workflow tasks from `/work-on`), append implementation tasks — never clear or replace the existing list.
 


### PR DESCRIPTION
## Why

`/plan` was producing linear plans even when work was parallelizable, and pausing after plan approval waiting for a "continue" prompt. Both are failure modes — sequential plans waste parallel throughput, and the pause breaks the flow after the user has already approved.

## What

- **Parallelization Mandate** — numbered interrogatives (not checkboxes) the agent verifies before presenting any plan; requires explicit justification if no parallel phase exists
- **Default-independent prior** in Step 3 — start from the assumption all tasks are independent; add `blockedBy` only when a real data dependency is found
- **Parallelization summary table** required in plan output (zero parallel phases must be explained, not silently omitted)
- **Bias toward action** in Step 9 — approval is the execution signal; next action is Step 10, not a summary or pause

## Notes for reviewers

The original approach used `- [ ]` checkboxes for the mandate. The reviewer flagged these as cosmetic — the model acknowledges them rather than computing against them. Switched to numbered interrogatives ("Does every independent task have no `blockedBy`?") which prompt active evaluation.

The "provably single-threaded (rare)" escape hatch in the first draft was also flagged as too soft. Replaced with a requirement to state the specific reason — forcing visible reasoning rather than silent rationalization.

Closes #321
Closes #322
